### PR TITLE
Running byzer-lang container on local mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,83 +1,34 @@
-# byzer-build
+# Byzer-build
 
 Project byzer-build comes with tools to build
-- byzer sandbox docker image
-- [byzer Engine](https://github.com/byzer-org/byzer-lang/) K8S image
-- byzer app
+- Byzer sandbox docker image
+- Byzer lang container
+- [Byzer-lang](https://github.com/byzer-org/byzer-lang/) K8S image
+- Byzer CLI
 
-## byzer Sandbox Docker Image
-With byzer Sandbox docker image, users are able to take a quick glance into byzer stack.
-
-### Pre-built image
+## Byzer Sandbox Docker Image
+With Byzer Sandbox docker image, users are able to take a quick glance into Byzer stack.
 Based on spark 2.4.3:
 ```
-docker pull byzer/byzer-lang-k8s:2.4.3-2.2.0-SNAPSHOT
+docker run -d --name sandbox -p 9002:9002 -p 9003:9003 -e MYSQL_ROOT_PASSWORD=root byzer/byzer-sandbox:2.4.3-latest
 ```
+
 
 Based on spark 3.1.1:
 ```
-docker pull byzer/byzer-lang-k8s:3.1.1-2.2.0-SNAPSHOT
-```
+docker run -d --name sandbox -p 9002:9002 -p 9003:9003 -e MYSQL_ROOT_PASSWORD=root byzer/byzer-sandbox:3.1.1-latest
 
-### Environment Variables
-```
-export SPARK_VERSION=<2.4.3 || 3.1.1>
-export BYZER_LANG_VERSION=2.2.0-SNAPSHOT
-```
-
-## Running sandbox
-
-### Pre-built image
-
-Based on spark 2.4.3:
-```
-docker pull byzer/byzer-sandbox:2.4.3-2.2.0-SNAPSHOT
-```
-
-Based on spark 3.1.1:
-```
-docker pull byzer/byzer-sandbox:3.1.1-2.2.0-SNAPSHOT
-```
-
-```shell
-sh ./dev/bin/run-sandbox-container.sh
-```
-
-We support specifying the mysql root password. For example, if the password is `root`, please pass it to the script as a parameter:
-```shell
-sh ./dev/bin/run-sandbox-container.sh root
-```
-
-It uses this command to deploy the container internally, as follows:
-
-```
-docker run -d \
--p 3306:3306 \
--p 9002:9002 \
--p 9003:9003 \
--e MYSQL_ROOT_HOST=% \
--e MYSQL_ROOT_PASSWORD="${MYSQL_PASSWORD}" \
---name mlsql-sandbox-${SPARK_VERSION}-${BYZER_LANG_VERSION} \
-byzer-sandbox:${SPARK_VERSION}-${BYZER_LANG_VERSION}
 ```
 
 ### Building Sandbox
 [Click for details](./docs/sandbox.md)
 
-## byzer Engine K8S Image
-
-Pre-built image: 
-
-```
-docker pull byzer/byzer-lang-k8s:3.1.1-2.2.0-SNAPSHOT
-```
-
-### Building byzer Engine K8S Image
-```shell
-./dev/bin/build-spark3-image.sh
-```
-
-Please find a step-by-step guide on K8S deployment from [byzer-k8s](https://github.com/byzer-org/byzer-k8s)
+## Byzer-lang Container
+`docker run -d --name byzer-lang -e DRIVER_MEMORY=8g -e MASTER=local[*] -p9003:9003 byzer/byzer-lang:3.1.1-latest`
+This command launches byzre-lang container with
+- heap size of 8GB
+- byzer-lang on local mode
+- exposes container's 9003 port 
 
 ## Byzer CLI
 To install and run the CLI, please visit [CLI doc](https://docs.byzer.org/#/byzer-lang/zh-cn/installation/cli-installation) .
@@ -101,3 +52,4 @@ For instance, to build Byzer CLI for linux spark 3.1.1 byzer-lang 2.2.0, run
 ## Multi-container deployment
 
 We provide scripts to start multiple microservices at once to facilitate us to build and start docker containers flexibly. Each service is deployed in an independent Ubuntu environment, which can isolate resources and environments.
+

--- a/dev/docker/compose-resource/kolo-lang/Dockerfile
+++ b/dev/docker/compose-resource/kolo-lang/Dockerfile
@@ -36,12 +36,13 @@ ENV BASE_DIR=/home/deploy \
 ENV KOLO_LANG_HOME="${BASE_DIR}/kolo-lang" \
     SPARK_HOME="/work/${SPARK_TGZ_NAME}" \
     HADOOP_HOME="/work/${HADOOP_TGZ_NAME:-hadoop-3.2.2}" \
-    SCALA_HOME="/work/${SCALA_TGZ_NAME}"
-
-ENV SPARK_VERSION="${SPARK_VERSION}" \
+    SCALA_HOME="/work/${SCALA_TGZ_NAME}" \
+    MLSQL_HOME="${BASE_DIR}/kolo-lang" \
+    MASTER="yarn" \
+    DRIVER_MEMORY="2g" \
+    SPARK_VERSION="${SPARK_VERSION}" \
     SPARK_TGZ_NAME="${SPARK_TGZ_NAME}" \
     HADOOP_TGZ_NAME="${HADOOP_TGZ_NAME}" \
-    MLSQL_HOME="${BASE_DIR}/kolo-lang" \
     PATH=$PATH:${KOLO_LANG_HOME}/bin:${SPARK_HOME}/sbin:${SPARK_HOME}/bin \
     BUILD_PATH=${BUILD_PATH}
 

--- a/dev/docker/compose-resource/kolo-lang/start-yarn.sh
+++ b/dev/docker/compose-resource/kolo-lang/start-yarn.sh
@@ -34,6 +34,8 @@ for env in SPARK_HOME ; do
   fi
 done
 
+[[ ${MASTER} == local* ]] && unset HADOOP_HOME && unset HADOOP_CONF_DIR
+
 ## 本脚本部署在${MLSQL_HOME}/bin 目录
 if [ -z "${MLSQL_HOME}" ]; then
   export MLSQL_HOME="$(cd "`dirname "$0"`"/..; pwd)"
@@ -61,7 +63,7 @@ sleep 5
 $SPARK_HOME/bin/spark-submit --class streaming.core.StreamingApp \
         --driver-memory ${DRIVER_MEMORY} \
         --jars ${JARS} \
-        --master yarn \
+        --master ${MASTER:-yarn} \
         --deploy-mode client \
         --name mlsql \
         --conf "spark.sql.hive.thriftServer.singleSession=true" \


### PR DESCRIPTION
Please see README.md for usage 
Test if  DRIVER_MEMORY and MASTER are effective
```shell
## Start container 
docker run -d --name lang -e DRIVER_MEMORY=8g -e MASTER=local[*] -p9003:9003 byzer/byzer-lang:3.1.1-2.2.2
## Check container memory setting
docker exec -it lang bash
ps -eaf | grep -i 8g
```

Result:
```
root        135      7 99 02:51 ?        00:00:30 /work/jdk1.8.0_151/bin/java -cp /home/deploy/kolo-lang/libs/ansj_seg-5.1.6.jar:/home/deploy/kolo-lang/libs/azure-blob_3.2-1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-assert-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-excel-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-ext-ets-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-mllib-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-shell-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/nlp-lang-1.7.8.jar:/home/deploy/kolo-lang/libs/streamingpro-mlsql-spark_3.0_2.12-2.2.2.jar:/work/spark-3.1.1-bin-hadoop3.2/conf/:/work/spark-3.1.1-bin-hadoop3.2/jars/*:/etc/hadoop -Xmx8g org.apache.spark.deploy.SparkSubmit --master local[*] --deploy-mode client --conf spark.driver.memory=8g --conf spark.kryoserializer.buffer.max=1024m --conf spark.sql.hive.thriftServer.singleSession=true --conf spark.executor.extraClassPath=/home/deploy/kolo-lang/libs/ansj_seg-5.1.6.jar:/home/deploy/kolo-lang/libs/azure-blob_3.2-1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-assert-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-excel-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-ext-ets-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-mllib-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-shell-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/nlp-lang-1.7.8.jar:/home/deploy/kolo-lang/libs/streamingpro-mlsql-spark_3.0_2.12-2.2.2.jar --conf spark.scheduler.mode=FAIR --conf spark.kryoserializer.buffer=256k --conf spark.serializer=org.apache.spark.serializer.KryoSerializer --conf spark.driver.extraClassPath=/home/deploy/kolo-lang/libs/ansj_seg-5.1.6.jar:/home/deploy/kolo-lang/libs/azure-blob_3.2-1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-assert-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-excel-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-ext-ets-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-mllib-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/mlsql-shell-3.0_2.12-0.1.0-SNAPSHOT.jar:/home/deploy/kolo-lang/libs/nlp-lang-1.7.8.jar:/home/deploy/kolo-lang/libs/streamingpro-mlsql-spark_3.0_2.12-2.2.2.jar --class streaming.core.StreamingApp --jars /home/deploy/kolo-lang/libs/ansj_seg-5.1.6.jar,/home/deploy/kolo-lang/libs/azure-blob_3.2-1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/mlsql-assert-3.0_2.12-0.1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/mlsql-excel-3.0_2.12-0.1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/mlsql-ext-ets-3.0_2.12-0.1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/mlsql-mllib-3.0_2.12-0.1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/mlsql-shell-3.0_2.12-0.1.0-SNAPSHOT.jar,/home/deploy/kolo-lang/libs/nlp-lang-1.7.8.jar,/home/deploy/kolo-lang/libs/streamingpro-mlsql-spark_3.0_2.12-2.2.2.jar --name mlsql /home/deploy/kolo-lang/libs/streamingpro-mlsql-spark_3.0_2.12-2.2.2.jar -streaming.name mlsql -streaming.platform spark -streaming.rest true -streaming.driver.port 9003 -streaming.spark.service true -streaming.thrift false -streaming.enableHiveSupport true -streaming.datalake.path /mlsql/_delta -streaming.plugin.clzznames tech.mlsql.plugins.ds.MLSQLExcelApp,tech.mlsql.plugins.assert.app.MLSQLAssert,tech.mlsql.plugins.shell.app.MLSQLShell,tech.mlsql.plugins.ext.ets.app.MLSQLETApp
```

